### PR TITLE
Add Android R8 keep rules

### DIFF
--- a/fmod/manifests/android/fmod.keep
+++ b/fmod/manifests/android/fmod.keep
@@ -1,0 +1,2 @@
+# The FMOD native libraries load vendor Java classes and methods by name through JNI.
+-keep,allowoptimization class org.fmod.** { *; }


### PR DESCRIPTION
Native Android code loads `org.fmod.FMOD` from the bundled `fmod/lib/android/fmod.jar` and calls `init` and `close` by name through JNI. Add `fmod/manifests/android/fmod.keep` to preserve the vendor Java classes and members during R8 shrinking and obfuscation. The JAR contains no embedded keep rules.

Applies the changes from `66d20565fc0f8d1aaaa6f42823e7ae18946ae715` on the latest `master`.

Validation: checked the Java bridge and native JNI references; verified that the branch contains one commit with the same patch as the supplied commit; `git diff --check` passes. Android builds and device tests were not run for this PR preparation.
